### PR TITLE
Migrate from master and slave terminology

### DIFF
--- a/venv/lib/python3.7/site-packages/django/apps/registry.py
+++ b/venv/lib/python3.7/site-packages/django/apps/registry.py
@@ -18,7 +18,7 @@ class Apps:
     """
 
     def __init__(self, installed_apps=()):
-        # installed_apps is set to None when creating the master registry
+        # installed_apps is set to None when creating the main registry
         # because it cannot be populated at that point. Other registries must
         # provide a list of installed apps and are populated immediately.
         if installed_apps is None and hasattr(sys.modules[__name__], 'apps'):
@@ -52,7 +52,7 @@ class Apps:
         # `lazy_model_operation()` and `do_pending_operations()` methods.
         self._pending_operations = defaultdict(list)
 
-        # Populate apps and models, unless it's the master registry.
+        # Populate apps and models, unless it's the main registry.
         if installed_apps is not None:
             self.populate(installed_apps)
 

--- a/venv/lib/python3.7/site-packages/django/conf/global_settings.py
+++ b/venv/lib/python3.7/site-packages/django/conf/global_settings.py
@@ -215,7 +215,7 @@ FORM_RENDERER = 'django.forms.renderers.DjangoTemplates'
 
 # Default email address to use for various automated correspondence from
 # the site managers.
-DEFAULT_FROM_EMAIL = 'webmaster@localhost'
+DEFAULT_FROM_EMAIL = 'webmain@localhost'
 
 # Subject-line prefix for email messages send with django.core.mail.mail_admins
 # or ...mail_managers.  Make sure to include the trailing space.

--- a/venv/lib/python3.7/site-packages/django/db/backends/sqlite3/introspection.py
+++ b/venv/lib/python3.7/site-packages/django/db/backends/sqlite3/introspection.py
@@ -60,7 +60,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         # Skip the sqlite_sequence system table used for autoincrement key
         # generation.
         cursor.execute("""
-            SELECT name, type FROM sqlite_master
+            SELECT name, type FROM sqlite_main
             WHERE type in ('table', 'view') AND NOT name='sqlite_sequence'
             ORDER BY name""")
         return [TableInfo(row[0], row[1][0]) for row in cursor.fetchall()]
@@ -97,7 +97,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
 
         # Schema for this table
         cursor.execute(
-            "SELECT sql, type FROM sqlite_master "
+            "SELECT sql, type FROM sqlite_main "
             "WHERE tbl_name = %s AND type IN ('table', 'view')",
             [table_name]
         )
@@ -127,7 +127,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
             else:
                 field_name = field_desc.split()[0].strip('"')
 
-            cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s", [table])
+            cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s", [table])
             result = cursor.fetchall()[0]
             other_table_results = result[0].strip()
             li, ri = other_table_results.index('('), other_table_results.rindex(')')
@@ -153,7 +153,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         key_columns = []
 
         # Schema for this table
-        cursor.execute("SELECT sql FROM sqlite_master WHERE tbl_name = %s AND type = %s", [table_name, "table"])
+        cursor.execute("SELECT sql FROM sqlite_main WHERE tbl_name = %s AND type = %s", [table_name, "table"])
         results = cursor.fetchone()[0].strip()
         results = results[results.index('(') + 1:results.rindex(')')]
 
@@ -178,7 +178,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
         """Return the column name of the primary key for the given table."""
         # Don't use PRAGMA because that causes issues with some transactions
         cursor.execute(
-            "SELECT sql, type FROM sqlite_master "
+            "SELECT sql, type FROM sqlite_main "
             "WHERE tbl_name = %s AND type IN ('table', 'view')",
             [table_name]
         )
@@ -255,7 +255,7 @@ class DatabaseIntrospection(BaseDatabaseIntrospection):
                 # SQLite doesn't support any index type other than b-tree
                 constraints[index]['type'] = Index.suffix
                 cursor.execute(
-                    "SELECT sql FROM sqlite_master "
+                    "SELECT sql FROM sqlite_main "
                     "WHERE type='index' AND name=%s" % self.connection.ops.quote_name(index)
                 )
                 orders = []

--- a/venv/lib/python3.7/site-packages/django/db/backends/sqlite3/schema.py
+++ b/venv/lib/python3.7/site-packages/django/db/backends/sqlite3/schema.py
@@ -121,15 +121,15 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
                     new_column_name = new_field.get_attname_column()[1]
                     search = references_template % old_column_name
                     replacement = references_template % new_column_name
-                    cursor.execute('UPDATE sqlite_master SET sql = replace(sql, %s, %s)', (search, replacement))
+                    cursor.execute('UPDATE sqlite_main SET sql = replace(sql, %s, %s)', (search, replacement))
                     cursor.execute('PRAGMA schema_version = %d' % (schema_version + 1))
                     cursor.execute('PRAGMA writable_schema = 0')
                     # The integrity check will raise an exception and rollback
-                    # the transaction if the sqlite_master updates corrupt the
+                    # the transaction if the sqlite_main updates corrupt the
                     # database.
                     cursor.execute('PRAGMA integrity_check')
             # Perform a VACUUM to refresh the database representation from
-            # the sqlite_master table.
+            # the sqlite_main table.
             with self.connection.cursor() as cursor:
                 cursor.execute('VACUUM')
         else:

--- a/venv/lib/python3.7/site-packages/django/test/client.py
+++ b/venv/lib/python3.7/site-packages/django/test/client.py
@@ -456,7 +456,7 @@ class Client(RequestFactory):
 
     def request(self, **request):
         """
-        The master request method. Compose the environment dictionary and pass
+        The main request method. Compose the environment dictionary and pass
         to the handler, return the result of the handler. Assume defaults for
         the query environment, which can be overridden using the arguments to
         the request.

--- a/venv/lib/python3.7/site-packages/django/test/runner.py
+++ b/venv/lib/python3.7/site-packages/django/test/runner.py
@@ -76,7 +76,7 @@ class RemoteTestResult:
     Record information about which tests have succeeded and which have failed.
 
     The sole purpose of this class is to record events in the child processes
-    so they can be replayed in the master process. As a consequence it doesn't
+    so they can be replayed in the main process. As a consequence it doesn't
     inherit unittest.TestResult and doesn't attempt to implement all its API.
 
     The implementation matches the unpythonic coding style of unittest2.

--- a/venv/lib/python3.7/site-packages/pip-10.0.1-py3.7.egg/pip/_internal/vcs/git.py
+++ b/venv/lib/python3.7/site-packages/pip-10.0.1-py3.7.egg/pip/_internal/vcs/git.py
@@ -169,7 +169,7 @@ class Git(VersionControl):
             self.run_command(['fetch', '-q', '--tags'], cwd=dest)
         else:
             self.run_command(['fetch', '-q'], cwd=dest)
-        # Then reset to wanted revision (maybe even origin/master)
+        # Then reset to wanted revision (maybe even origin/main)
         rev_options = self.check_rev_options(dest, rev_options)
         cmd_args = ['reset', '--hard', '-q'] + rev_options.to_args()
         self.run_command(cmd_args, cwd=dest)

--- a/venv/lib/python3.7/site-packages/pip-10.0.1-py3.7.egg/pip/_vendor/pkg_resources/__init__.py
+++ b/venv/lib/python3.7/site-packages/pip-10.0.1-py3.7.egg/pip/_vendor/pkg_resources/__init__.py
@@ -558,9 +558,9 @@ class WorkingSet(object):
             self.add_entry(entry)
 
     @classmethod
-    def _build_master(cls):
+    def _build_main(cls):
         """
-        Prepare the master working set.
+        Prepare the main working set.
         """
         ws = cls()
         try:
@@ -3086,9 +3086,9 @@ def _initialize(g=globals()):
 
 
 @_call_aside
-def _initialize_master_working_set():
+def _initialize_main_working_set():
     """
-    Prepare the master working set and make the ``require()``
+    Prepare the main working set and make the ``require()``
     API available.
 
     This function has explicit effects on the global state
@@ -3098,7 +3098,7 @@ def _initialize_master_working_set():
     Invocation by other packages is unsupported and done
     at their own risk.
     """
-    working_set = WorkingSet._build_master()
+    working_set = WorkingSet._build_main()
     _declare_state('object', working_set=working_set)
 
     require = working_set.require


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.